### PR TITLE
Improvements on current generators and added more tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <instancio.version>3.6.0</instancio.version>
     <vavr.version>0.10.4</vavr.version>
     <junit.version>5.10.1</junit.version>
-    <assertj.version>3.11.1</assertj.version>
+    <assertj.version>3.24.2</assertj.version>
     <logback.version>1.4.8</logback.version>
   </properties>
 

--- a/src/main/java/ch/movementsciences/instancio/vavr/generator/specs/CharSeqSpecs.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/generator/specs/CharSeqSpecs.java
@@ -16,11 +16,13 @@
 
 package ch.movementsciences.instancio.vavr.generator.specs;
 
+import io.vavr.collection.CharSeq;
+import org.instancio.generator.specs.NullableGeneratorSpec;
 import org.instancio.generator.specs.SizeGeneratorSpec;
 
-import io.vavr.collection.CharSeq;
-
-public interface CharSeqSpecs extends SizeGeneratorSpec<CharSeq> {
+public interface CharSeqSpecs extends
+        SizeGeneratorSpec<CharSeq>,
+        NullableGeneratorSpec<CharSeq> {
     @Override
     CharSeqSpecs size(int size);
 
@@ -31,4 +33,7 @@ public interface CharSeqSpecs extends SizeGeneratorSpec<CharSeq> {
     CharSeqSpecs maxSize(int size);
 
     CharSeqSpecs with(String str);
+
+    @Override
+    CharSeqSpecs nullable();
 }

--- a/src/main/java/ch/movementsciences/instancio/vavr/generator/specs/SeqSpecs.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/generator/specs/SeqSpecs.java
@@ -16,18 +16,15 @@
 
 package ch.movementsciences.instancio.vavr.generator.specs;
 
-import java.util.Collection;
-
+import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
+import org.instancio.generator.specs.NullableGeneratorSpec;
 import org.instancio.generator.specs.SizeGeneratorSpec;
 import org.instancio.generator.specs.SubtypeGeneratorSpec;
 
-import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
-import io.vavr.collection.Seq;
-
 public interface SeqSpecs<T> extends
         SizeGeneratorSpec<SeqBuilder<T>>,
-        SubtypeGeneratorSpec<SeqBuilder<T>>
-{
+        SubtypeGeneratorSpec<SeqBuilder<T>>,
+        NullableGeneratorSpec<SeqBuilder<T>> {
     @Override
     SeqSpecs<T> size(int size);
 
@@ -40,5 +37,9 @@ public interface SeqSpecs<T> extends
     @Override
     SeqSpecs<T> subtype(Class<?> type);
 
-    SeqSpecs<T> with(T ...elements);
+    @SuppressWarnings("unchecked")
+    SeqSpecs<T> with(T... elements);
+
+    @Override
+    SeqSpecs<T> nullable();
 }

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/builder/SeqBuilder.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/builder/SeqBuilder.java
@@ -16,6 +16,13 @@
 
 package ch.movementsciences.instancio.vavr.internal.builder;
 
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+import static java.util.function.Predicate.isEqual;
+
+import java.util.Collection;
+
 import io.vavr.collection.Array;
 import io.vavr.collection.IndexedSeq;
 import io.vavr.collection.List;
@@ -23,13 +30,6 @@ import io.vavr.collection.Queue;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import io.vavr.collection.Vector;
-
-import java.util.Collection;
-
-import static io.vavr.API.$;
-import static io.vavr.API.Case;
-import static io.vavr.API.Match;
-import static java.util.function.Predicate.isEqual;
 
 public record SeqBuilder<T>(Collection<T> items) implements VavrBuilder<Seq<T>> {
 

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/builder/SeqBuilder.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/builder/SeqBuilder.java
@@ -16,17 +16,20 @@
 
 package ch.movementsciences.instancio.vavr.internal.builder;
 
-import static io.vavr.API.*;
-import static java.util.function.Predicate.isEqual;
-
-import java.util.Collection;
-
 import io.vavr.collection.Array;
+import io.vavr.collection.IndexedSeq;
 import io.vavr.collection.List;
 import io.vavr.collection.Queue;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import io.vavr.collection.Vector;
+
+import java.util.Collection;
+
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+import static java.util.function.Predicate.isEqual;
 
 public record SeqBuilder<T>(Collection<T> items) implements VavrBuilder<Seq<T>> {
 
@@ -41,13 +44,14 @@ public record SeqBuilder<T>(Collection<T> items) implements VavrBuilder<Seq<T>> 
     @Override
     public Seq<T> build(Class<?> type) {
         return Match(type).of(
+                Case($(isEqual(IndexedSeq.class)), () -> Array.ofAll(items)),
                 Case($(isEqual(Array.class)), () -> Array.ofAll(items)),
                 Case($(isEqual(Vector.class)), () -> Vector.ofAll(items)),
                 Case($(isEqual(List.class)), () -> List.ofAll(items)),
                 Case($(isEqual(Stream.class)), () -> Stream.ofAll(items)),
                 Case($(isEqual(Queue.class)), () -> Queue.ofAll(items)),
                 Case($(), () -> List.ofAll(items))
-        );  
+        );
     }
-    
+
 }

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/generator/CharSeqGenerator.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/generator/CharSeqGenerator.java
@@ -16,38 +16,43 @@
 
 package ch.movementsciences.instancio.vavr.internal.generator;
 
-import org.instancio.Random;
-import org.instancio.generator.Generator;
-import org.instancio.generator.GeneratorContext;
-import org.instancio.generator.Hints;
-import org.instancio.internal.ApiValidator;
-import org.instancio.internal.generator.InternalContainerHint;
-import org.instancio.internal.generator.InternalGeneratorHint;
-import org.instancio.internal.generator.lang.StringGenerator;
-import org.instancio.internal.util.Constants;
-import org.instancio.internal.util.NumberUtils;
-
 import ch.movementsciences.instancio.vavr.generator.specs.CharSeqSpecs;
-import ch.movementsciences.instancio.vavr.generator.specs.SeqSpecs;
-import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
 import io.vavr.collection.CharSeq;
 import io.vavr.collection.List;
+import org.instancio.Random;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.ApiValidator;
+import org.instancio.internal.generator.AbstractGenerator;
+import org.instancio.internal.generator.lang.StringGenerator;
+import org.instancio.internal.util.NumberUtils;
+import org.instancio.settings.Keys;
+import org.instancio.support.Global;
 
-public class CharSeqGenerator implements Generator<CharSeq>, CharSeqSpecs {
+public class CharSeqGenerator extends AbstractGenerator<CharSeq> implements CharSeqSpecs {
 
-    private GeneratorContext context;
-    private int minSize = Constants.MIN_SIZE;
-    private int maxSize = Constants.MAX_SIZE;
+    protected int minSize;
+    protected int maxSize;
     private CharSeq withElements = CharSeq.empty();
 
-    @Override
-    public void init(final GeneratorContext context) {
-        this.context = context;
+    public CharSeqGenerator(final GeneratorContext context) {
+        super(context);
+        super.nullable(context.getSettings().get(Keys.COLLECTION_NULLABLE));
+        this.minSize = context.getSettings().get(Keys.COLLECTION_MIN_SIZE);
+        this.maxSize = context.getSettings().get(Keys.COLLECTION_MAX_SIZE);
+    }
+
+    public CharSeqGenerator() {
+        this(Global.generatorContext());
     }
 
     @Override
-    public CharSeq generate(final Random random) {
-        final var str = new StringGenerator(context)
+    public String apiMethod() {
+        return null;
+    }
+
+    @Override
+    protected CharSeq tryGenerateNonNull(final Random random) {
+        final var str = new StringGenerator(getContext())
                 .minLength(maxSize)
                 .maxLength(maxSize)
                 .generate(random);
@@ -80,6 +85,18 @@ public class CharSeqGenerator implements Generator<CharSeq>, CharSeqSpecs {
     public final CharSeqSpecs with(String str) {
         ApiValidator.isFalse(str.isEmpty(), "'chaSeq().with(...)' must contain a non-empty string");
         withElements = withElements.appendAll(List.ofAll(str.toCharArray()));
+        return this;
+    }
+
+    @Override
+    public CharSeqSpecs nullable() {
+        super.nullable(true);
+        return this;
+    }
+
+    @Override
+    public CharSeqSpecs nullable(final boolean isNullable) {
+        super.nullable(isNullable);
         return this;
     }
 }

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGenerator.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGenerator.java
@@ -33,8 +33,8 @@ import org.instancio.support.Global;
 
 public class SeqGenerator<T> extends AbstractGenerator<SeqBuilder<T>> implements SeqSpecs<T> {
 
-    private int minSize;
-    private int maxSize;
+    protected int minSize;
+    protected int maxSize;
     private Class<?> subtype;
     private List<T> withElements = List.empty();
 
@@ -55,7 +55,7 @@ public class SeqGenerator<T> extends AbstractGenerator<SeqBuilder<T>> implements
     }
 
     @Override
-    public SeqBuilder<T> tryGenerateNonNull(final Random random) {
+    protected SeqBuilder<T> tryGenerateNonNull(final Random random) {
         return SeqBuilder.from(withElements);
     }
 

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGenerator.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGenerator.java
@@ -20,29 +20,27 @@ import ch.movementsciences.instancio.vavr.generator.specs.SeqSpecs;
 import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
 import io.vavr.collection.List;
 import org.instancio.Random;
-import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.Hints;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.RandomHelper;
+import org.instancio.internal.generator.AbstractGenerator;
 import org.instancio.internal.generator.InternalContainerHint;
 import org.instancio.internal.generator.InternalGeneratorHint;
 import org.instancio.internal.util.NumberUtils;
 import org.instancio.settings.Keys;
 import org.instancio.support.Global;
 
-public class SeqGenerator<T> implements Generator<SeqBuilder<T>>, SeqSpecs<T> {
+public class SeqGenerator<T> extends AbstractGenerator<SeqBuilder<T>> implements SeqSpecs<T> {
 
-    private GeneratorContext context;
     private int minSize;
     private int maxSize;
     private Class<?> subtype;
     private List<T> withElements = List.empty();
-    private boolean nullable = false;
 
     public SeqGenerator(final GeneratorContext context) {
-        this.context = context;
-        this.nullable(context.getSettings().get(Keys.COLLECTION_NULLABLE));
+        super(context);
+        super.nullable(context.getSettings().get(Keys.COLLECTION_NULLABLE));
         this.minSize = context.getSettings().get(Keys.COLLECTION_MIN_SIZE);
         this.maxSize = context.getSettings().get(Keys.COLLECTION_MAX_SIZE);
     }
@@ -52,8 +50,13 @@ public class SeqGenerator<T> implements Generator<SeqBuilder<T>>, SeqSpecs<T> {
     }
 
     @Override
-    public SeqBuilder<T> generate(final Random random) {
-        return random.diceRoll(isNullable()) ? null : SeqBuilder.from(withElements);
+    public String apiMethod() {
+        return null;
+    }
+
+    @Override
+    public SeqBuilder<T> tryGenerateNonNull(final Random random) {
+        return SeqBuilder.from(withElements);
     }
 
     @SuppressWarnings("unchecked")
@@ -67,7 +70,8 @@ public class SeqGenerator<T> implements Generator<SeqBuilder<T>>, SeqSpecs<T> {
                 .with(InternalGeneratorHint.builder()
                         .nullableResult(isNullable())
                         .targetClass(subtype)
-                        .build()).build();
+                        .build())
+                .build();
     }
 
     @Override
@@ -107,22 +111,19 @@ public class SeqGenerator<T> implements Generator<SeqBuilder<T>>, SeqSpecs<T> {
 
     @Override
     public SeqSpecs<T> nullable() {
-        nullable = true;
+        super.nullable(true);
         return this;
     }
 
+    @Override
     public SeqSpecs<T> nullable(final boolean isNullable) {
-        nullable = isNullable;
+        super.nullable(isNullable);
         return this;
-    }
-
-    public final boolean isNullable() {
-        return nullable;
     }
 
     private Random getRandom() {
-        return context.random() != null
-                ? context.random()
-                : RandomHelper.resolveRandom(context.getSettings().get(Keys.SEED), null);
+        return getContext().random() != null
+                ? getContext().random()
+                : RandomHelper.resolveRandom(getContext().getSettings().get(Keys.SEED), null);
     }
 }

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrContainerFactory.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrContainerFactory.java
@@ -16,21 +16,23 @@
 
 package ch.movementsciences.instancio.vavr.internal.spi;
 
-import java.util.function.Function;
-
+import ch.movementsciences.instancio.vavr.internal.builder.VavrBuilder;
+import io.vavr.collection.CharSeq;
+import io.vavr.collection.Seq;
 import org.instancio.internal.spi.InternalContainerFactoryProvider;
 
-import ch.movementsciences.instancio.vavr.internal.builder.VavrBuilder;
-import io.vavr.collection.Seq;
+import java.util.function.Function;
 
 public class VavrContainerFactory implements InternalContainerFactoryProvider {
 
     @Override
     public <T, R> Function<T, R> getMappingFunction(Class<R> type, java.util.List<Class<?>> typeArguments) {
-        return (t) -> {
+        return (T t) -> {
             if (t instanceof VavrBuilder<?> builder) {
                 final var builtType = builder.build(type);
                 return type.cast(builtType);
+            } else if (t instanceof CharSeq charSeq) {
+                return type.cast(charSeq);
             }
             return null;
         };

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrContainerFactory.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrContainerFactory.java
@@ -16,12 +16,12 @@
 
 package ch.movementsciences.instancio.vavr.internal.spi;
 
+import java.util.function.Function;
+
 import ch.movementsciences.instancio.vavr.internal.builder.VavrBuilder;
 import io.vavr.collection.CharSeq;
 import io.vavr.collection.Seq;
 import org.instancio.internal.spi.InternalContainerFactoryProvider;
-
-import java.util.function.Function;
 
 public class VavrContainerFactory implements InternalContainerFactoryProvider {
 

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
@@ -16,6 +16,7 @@
 
 package ch.movementsciences.instancio.vavr.internal.spi;
 
+import ch.movementsciences.instancio.vavr.internal.generator.CharSeqGenerator;
 import ch.movementsciences.instancio.vavr.internal.generator.SeqGenerator;
 import io.vavr.collection.CharSeq;
 import io.vavr.collection.Seq;

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
@@ -16,23 +16,34 @@
 
 package ch.movementsciences.instancio.vavr.internal.spi;
 
-import static io.vavr.API.*;
-
-import org.instancio.Node;
-import org.instancio.generators.Generators;
-import org.instancio.spi.InstancioServiceProvider;
-
-import ch.movementsciences.instancio.vavr.internal.generator.CharSeqGenerator;
 import ch.movementsciences.instancio.vavr.internal.generator.SeqGenerator;
 import io.vavr.collection.CharSeq;
 import io.vavr.collection.Seq;
+import org.instancio.Node;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generators.Generators;
+import org.instancio.spi.InstancioServiceProvider;
+import org.instancio.spi.ServiceProviderContext;
+
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
 
 public class VavrProvider implements InstancioServiceProvider {
+
+    private GeneratorContext generatorContext;
+
+    @Override
+    public void init(final ServiceProviderContext providerContext) {
+        this.generatorContext = new GeneratorContext(
+                providerContext.getSettings(),
+                providerContext.random());
+    }
     @Override
     public GeneratorProvider getGeneratorProvider() {
         return (Node node, Generators gen) -> Match(node.getTargetClass()).of(
                 Case($(CharSeq.class::isAssignableFrom), CharSeqGenerator::new),
-                Case($(Seq.class::isAssignableFrom), () -> new SeqGenerator<>()),
+                Case($(Seq.class::isAssignableFrom), () -> new SeqGenerator<>(generatorContext)),
                 Case($(), () -> null)
         );
     }

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
@@ -26,9 +26,7 @@ import org.instancio.generators.Generators;
 import org.instancio.spi.InstancioServiceProvider;
 import org.instancio.spi.ServiceProviderContext;
 
-import static io.vavr.API.$;
-import static io.vavr.API.Case;
-import static io.vavr.API.Match;
+import static io.vavr.API.*;
 
 public class VavrProvider implements InstancioServiceProvider {
 
@@ -43,7 +41,7 @@ public class VavrProvider implements InstancioServiceProvider {
     @Override
     public GeneratorProvider getGeneratorProvider() {
         return (Node node, Generators gen) -> Match(node.getTargetClass()).of(
-                Case($(CharSeq.class::isAssignableFrom), CharSeqGenerator::new),
+                Case($(CharSeq.class::isAssignableFrom), () -> new CharSeqGenerator(generatorContext)),
                 Case($(Seq.class::isAssignableFrom), () -> new SeqGenerator<>(generatorContext)),
                 Case($(), () -> null)
         );

--- a/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
+++ b/src/main/java/ch/movementsciences/instancio/vavr/internal/spi/VavrProvider.java
@@ -16,6 +16,10 @@
 
 package ch.movementsciences.instancio.vavr.internal.spi;
 
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+
 import ch.movementsciences.instancio.vavr.internal.generator.CharSeqGenerator;
 import ch.movementsciences.instancio.vavr.internal.generator.SeqGenerator;
 import io.vavr.collection.CharSeq;
@@ -25,8 +29,6 @@ import org.instancio.generator.GeneratorContext;
 import org.instancio.generators.Generators;
 import org.instancio.spi.InstancioServiceProvider;
 import org.instancio.spi.ServiceProviderContext;
-
-import static io.vavr.API.*;
 
 public class VavrProvider implements InstancioServiceProvider {
 
@@ -38,6 +40,7 @@ public class VavrProvider implements InstancioServiceProvider {
                 providerContext.getSettings(),
                 providerContext.random());
     }
+
     @Override
     public GeneratorProvider getGeneratorProvider() {
         return (Node node, Generators gen) -> Match(node.getTargetClass()).of(

--- a/src/test/java/ch/movementsciences/instancio/vavr/AllSupportedVavrTypes.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/AllSupportedVavrTypes.java
@@ -16,13 +16,7 @@
 
 package ch.movementsciences.instancio.vavr;
 
-import io.vavr.collection.Array;
-import io.vavr.collection.IndexedSeq;
-import io.vavr.collection.List;
-import io.vavr.collection.Queue;
-import io.vavr.collection.Seq;
-import io.vavr.collection.Stream;
-import io.vavr.collection.Vector;
+import io.vavr.collection.*;
 
 import java.util.UUID;
 
@@ -30,10 +24,12 @@ public record AllSupportedVavrTypes(
 
         // Sequences
         Seq<UUID> seq,
-        List<UUID> list,
-        Queue<UUID> queue,
-        Stream<UUID> stream,
         IndexedSeq<UUID> indexedSeq,
         Array<UUID> array,
-        Vector<UUID> vector
+        Vector<UUID> vector,
+        LinearSeq<UUID> linearSeq,
+        List<UUID> list,
+        Stream<UUID> stream,
+        Queue<UUID> queue,
+        CharSeq charSeq
 ) {}

--- a/src/test/java/ch/movementsciences/instancio/vavr/AllSupportedVavrTypes.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/AllSupportedVavrTypes.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 MovementSciences AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.movementsciences.instancio.vavr;
+
+import io.vavr.collection.Array;
+import io.vavr.collection.IndexedSeq;
+import io.vavr.collection.List;
+import io.vavr.collection.Queue;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Stream;
+import io.vavr.collection.Vector;
+
+import java.util.UUID;
+
+public record AllSupportedVavrTypes(
+
+        // Sequences
+        Seq<UUID> seq,
+        List<UUID> list,
+        Queue<UUID> queue,
+        Stream<UUID> stream,
+        IndexedSeq<UUID> indexedSeq,
+        Array<UUID> array,
+        Vector<UUID> vector
+) {}

--- a/src/test/java/ch/movementsciences/instancio/vavr/CharSeqTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/CharSeqTest.java
@@ -16,19 +16,20 @@
 
 package ch.movementsciences.instancio.vavr;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Select.all;
-import static org.instancio.Select.types;
-
+import io.vavr.collection.CharSeq;
+import io.vavr.collection.Seq;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.internal.util.Constants;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.vavr.collection.CharSeq;
-import io.vavr.collection.Seq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.types;
 
 @ExtendWith(InstancioExtension.class)
 class CharSeqTest {
@@ -42,8 +43,10 @@ class CharSeqTest {
     void createListViaTypeToken() {
         final var result = Instancio.create(new TypeToken<CharSeq>() {});
 
-        assertThat(result.getClass()).isEqualTo(CharSeq.class);
-        assertThat(result.size()).isBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+
+        assertThat((Iterable<?>) result)
+                .isInstanceOf(CharSeq.class)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
     }
 
     @Test
@@ -52,8 +55,23 @@ class CharSeqTest {
                 .generate(types().of(Seq.class), GenVavr.charSeq().size(EXPECTED_SIZE))
                 .create();
 
-        assertThat(result.getClass()).isEqualTo(CharSeq.class);
-        assertThat(result.size()).isEqualTo(EXPECTED_SIZE);
+        assertThat((Iterable<?>) result)
+                .isInstanceOf(CharSeq.class)
+                .hasSize(EXPECTED_SIZE)
+                .doesNotContainNull();
+    }
+
+    @Test
+    void generatorSettingsSize() {
+        final var result = Instancio.of(new TypeToken<CharSeq>() {})
+                .withSettings(Settings.create()
+                        .set(Keys.COLLECTION_MIN_SIZE, 1)
+                        .set(Keys.COLLECTION_MAX_SIZE, 10))
+                .create();
+
+        assertThat((Iterable<?>) result)
+                .isInstanceOf(CharSeq.class)
+                .hasSizeBetween(1, 10);
     }
 
     @Test

--- a/src/test/java/ch/movementsciences/instancio/vavr/SeqTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/SeqTest.java
@@ -16,20 +16,21 @@
 
 package ch.movementsciences.instancio.vavr;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Select.all;
-import static org.instancio.Select.types;
-
+import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.internal.util.Constants;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.vavr.collection.List;
-import io.vavr.collection.Seq;
-import io.vavr.collection.Vector;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.types;
 
 @ExtendWith(InstancioExtension.class)
 class SeqTest {
@@ -43,8 +44,9 @@ class SeqTest {
     void createListViaTypeToken() {
         final var result = Instancio.create(new TypeToken<Seq<String>>() {});
 
-        assertThat(result).isInstanceOf(List.class);
-        assertThat(result.size()).isBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+        assertThat(result)
+                .isInstanceOf(List.class)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
     }
 
     @Test
@@ -60,12 +62,27 @@ class SeqTest {
     }
 
     @Test
+    void generatorSettingsSize() {
+        final var result = Instancio.of(new TypeToken<Seq<String>>() {})
+                .withSettings(Settings.create()
+                        .set(Keys.COLLECTION_MIN_SIZE, 1)
+                        .set(Keys.COLLECTION_MAX_SIZE, 10))
+                .create();
+
+        assertThat(result)
+                .isInstanceOf(List.class)
+                .hasSizeBetween(1, 10);
+    }
+
+    @Test
     void generatorSpecSubtype() {
         final var result = Instancio.of(Holder.class)
                 .subtype(all(Seq.class), Vector.class)
                 .create();
 
-        assertThat(result.seq).isInstanceOf(Vector.class);
+        assertThat(result.seq)
+                .isInstanceOf(Seq.class)
+                .isExactlyInstanceOf(Vector.class);
     }
 
     @Test
@@ -76,7 +93,8 @@ class SeqTest {
                 .create();
 
         assertThat(result.seq)
-                .isInstanceOf(Vector.class)
+                .isInstanceOf(Seq.class)
+                .isExactlyInstanceOf(Vector.class)
                 .hasSize(EXPECTED_SIZE)
                 .doesNotContainNull();
     }

--- a/src/test/java/ch/movementsciences/instancio/vavr/SupportedSeqTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/SupportedSeqTest.java
@@ -42,6 +42,8 @@ class SupportedSeqTest {
                 Arguments.of(new TypeToken<IndexedSeq<UUID>>() {}, IndexedSeq.class),
                 Arguments.of(new TypeToken<Array<UUID>>() {}, Array.class),
                 Arguments.of(new TypeToken<Vector<UUID>>() {}, Vector.class),
+                Arguments.of(new TypeToken<Seq<UUID>>() {}, Seq.class),
+                Arguments.of(new TypeToken<LinearSeq<UUID>>() {}, LinearSeq.class),
                 Arguments.of(new TypeToken<List<UUID>>() {}, List.class),
                 Arguments.of(new TypeToken<Stream<UUID>>() {}, Stream.class),
                 Arguments.of(new TypeToken<Queue<UUID>>() {}, Queue.class)

--- a/src/test/java/ch/movementsciences/instancio/vavr/SupportedSeqTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/SupportedSeqTest.java
@@ -16,11 +16,14 @@
 
 package ch.movementsciences.instancio.vavr;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Select.root;
-
-import java.util.UUID;
-
+import io.vavr.collection.Array;
+import io.vavr.collection.IndexedSeq;
+import io.vavr.collection.LinearSeq;
+import io.vavr.collection.List;
+import io.vavr.collection.Queue;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Stream;
+import io.vavr.collection.Vector;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.internal.util.Constants;
@@ -28,16 +31,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.vavr.collection.Array;
-import io.vavr.collection.List;
-import io.vavr.collection.Queue;
-import io.vavr.collection.Seq;
-import io.vavr.collection.Stream;
-import io.vavr.collection.Vector;
+import java.util.UUID;
 
-public class SupportedSeqTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+class SupportedSeqTest {
     private static java.util.List<Arguments> args() {
         return java.util.List.of(
+                Arguments.of(new TypeToken<IndexedSeq<UUID>>() {}, IndexedSeq.class),
                 Arguments.of(new TypeToken<Array<UUID>>() {}, Array.class),
                 Arguments.of(new TypeToken<Vector<UUID>>() {}, Vector.class),
                 Arguments.of(new TypeToken<List<UUID>>() {}, List.class),

--- a/src/test/java/ch/movementsciences/instancio/vavr/SupportedSeqTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/SupportedSeqTest.java
@@ -16,14 +16,7 @@
 
 package ch.movementsciences.instancio.vavr;
 
-import io.vavr.collection.Array;
-import io.vavr.collection.IndexedSeq;
-import io.vavr.collection.LinearSeq;
-import io.vavr.collection.List;
-import io.vavr.collection.Queue;
-import io.vavr.collection.Seq;
-import io.vavr.collection.Stream;
-import io.vavr.collection.Vector;
+import io.vavr.collection.*;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.internal.util.Constants;
@@ -39,10 +32,10 @@ import static org.instancio.Select.root;
 class SupportedSeqTest {
     private static java.util.List<Arguments> args() {
         return java.util.List.of(
+                Arguments.of(new TypeToken<Seq<UUID>>() {}, Seq.class),
                 Arguments.of(new TypeToken<IndexedSeq<UUID>>() {}, IndexedSeq.class),
                 Arguments.of(new TypeToken<Array<UUID>>() {}, Array.class),
                 Arguments.of(new TypeToken<Vector<UUID>>() {}, Vector.class),
-                Arguments.of(new TypeToken<Seq<UUID>>() {}, Seq.class),
                 Arguments.of(new TypeToken<LinearSeq<UUID>>() {}, LinearSeq.class),
                 Arguments.of(new TypeToken<List<UUID>>() {}, List.class),
                 Arguments.of(new TypeToken<Stream<UUID>>() {}, Stream.class),

--- a/src/test/java/ch/movementsciences/instancio/vavr/VavrRepeatabilityTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/VavrRepeatabilityTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 MovementSciences AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.movementsciences.instancio.vavr;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.Seed;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(InstancioExtension.class)
+class VavrRepeatabilityTest {
+
+    private static final long SEED = 12345L;
+
+    private static AllSupportedVavrTypes first;
+
+    @Seed(SEED)
+    @Order(1)
+    @Test
+    void first() {
+        first = Instancio.create(AllSupportedVavrTypes.class);
+
+        assertThat(first).hasNoNullFieldsOrProperties();
+    }
+
+    @Seed(SEED)
+    @Order(2)
+    @Test
+    void second() {
+        AllSupportedVavrTypes second = Instancio.create(AllSupportedVavrTypes.class);
+
+        assertThat(second)
+                .usingRecursiveComparison()
+                .isEqualTo(first);
+    }
+}

--- a/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/CharSeqSpecsTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/CharSeqSpecsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.movementsciences.instancio.vavr.generator.specs;
+
+import ch.movementsciences.instancio.vavr.internal.generator.CharSeqGenerator;
+import io.vavr.collection.CharSeq;
+import org.instancio.Random;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.exception.InstancioException;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.util.Constants;
+import org.instancio.settings.Settings;
+import org.instancio.support.DefaultRandom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CharSeqSpecsTest {
+
+    private static final int PERCENTAGE = Constants.RANGE_ADJUSTMENT_PERCENTAGE;
+    private final GeneratorContext context = new GeneratorContext(Settings.defaults(), new DefaultRandom());
+    private final CharSeqGeneratorExt<?> generator = new CharSeqGeneratorExt<>(context);
+
+    @BeforeEach
+    void setUp() {
+        generator.minSize(0).minSize(1);
+    }
+
+    @Test
+    @DisplayName("newMax < min: new min should be less than newMax by PERCENTAGE")
+    void newMaxIsLessThanMin() {
+        final var newMax = 50;
+
+        generator.minSize(Integer.MAX_VALUE).maxSize(newMax);
+
+        assertThat(generator.getMinSize())
+                .isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
+    }
+
+    @Test
+    @DisplayName("newMax == min: new min should be less than newMax by PERCENTAGE")
+    void newMaxIsEqualToMin() {
+        final var newMax = 100;
+
+        generator.minSize(Integer.MAX_VALUE).maxSize(newMax);
+
+        assertThat(generator.getMinSize())
+                .isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
+    }
+
+    @Test
+    @DisplayName("newMin > max: new max should be set to greater than newMin by PERCENTAGE")
+    void newMinIsGreaterThanMax() {
+        final var newMin = 100;
+
+        generator.minSize(newMin);
+
+        assertThat(generator.getMaxSize())
+                .isEqualTo(calculatePercentage(newMin, PERCENTAGE));
+    }
+
+    @Test
+    @DisplayName("newMin == max: new max should be set to greater than newMin by PERCENTAGE")
+    void newMinIsEqualToMax() {
+        final var newMin = 100;
+
+        generator.maxSize(0).minSize(newMin);
+
+        assertThat(generator.getMaxSize())
+                .isEqualTo(calculatePercentage(newMin, PERCENTAGE));
+    }
+
+    @Test
+    void size() {
+        final var size = 2;
+
+        generator.size(size);
+
+        assertThat(generator.getMinSize()).isEqualTo(size);
+        assertThat(generator.getMaxSize()).isEqualTo(size);
+    }
+
+    @Test
+    void minValidation() {
+        assertThatThrownBy(() -> generator.minSize(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContaining("size must not be negative: -1");
+    }
+
+    @Test
+    void maxValidation() {
+        assertThatThrownBy(() -> generator.maxSize(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContaining("size must not be negative: -1");
+    }
+
+    private int calculatePercentage(final int initial, final int percentage) {
+        return initial + initial * percentage / 100;
+    }
+
+    /**
+     * Subclass to expose getters.
+     */
+    private static class CharSeqGeneratorExt<T> extends CharSeqGenerator {
+
+        public CharSeqGeneratorExt(final GeneratorContext context) {
+            super(context);
+        }
+
+        @Override
+        protected CharSeq tryGenerateNonNull(final Random random) {
+            throw new InstancioException(getClass() + " should delegate to another generator");
+        }
+
+        int getMinSize() {
+            return minSize;
+        }
+
+        int getMaxSize() {
+            return maxSize;
+        }
+    }
+
+}

--- a/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/CharSeqSpecsTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/CharSeqSpecsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright (c) 2023 MovementSciences AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package ch.movementsciences.instancio.vavr.generator.specs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ch.movementsciences.instancio.vavr.internal.generator.CharSeqGenerator;
 import io.vavr.collection.CharSeq;
@@ -27,9 +31,6 @@ import org.instancio.support.DefaultRandom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CharSeqSpecsTest {
 

--- a/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/SeqSpecsTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/SeqSpecsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.movementsciences.instancio.vavr.generator.specs;
+
+import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
+import ch.movementsciences.instancio.vavr.internal.generator.SeqGenerator;
+import org.instancio.Random;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.exception.InstancioException;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.util.Constants;
+import org.instancio.settings.Settings;
+import org.instancio.support.DefaultRandom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SeqSpecsTest {
+
+    private static final int PERCENTAGE = Constants.RANGE_ADJUSTMENT_PERCENTAGE;
+    private final GeneratorContext context = new GeneratorContext(Settings.defaults(), new DefaultRandom());
+    private final SeqGeneratorExt<?> generator = new SeqGeneratorExt<>(context);
+
+    @BeforeEach
+    void setUp() {
+        generator.minSize(0).minSize(1);
+    }
+
+    @Test
+//    @DisplayName("newMax < min: new min should be less than newMax by PERCENTAGE")
+    void newMaxIsLessThanMin() {
+        final var newMax = 50;
+
+        generator.minSize(Integer.MAX_VALUE).maxSize(newMax);
+
+        assertThat(generator.getMinSize())
+                .isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
+    }
+
+    @Test
+    @DisplayName("newMax == min: new min should be less than newMax by PERCENTAGE")
+    void newMaxIsEqualToMin() {
+        final var newMax = 100;
+
+        generator.minSize(Integer.MAX_VALUE).maxSize(newMax);
+
+        assertThat(generator.getMinSize())
+                .isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
+    }
+
+    @Test
+    @DisplayName("newMin > max: new max should be set to greater than newMin by PERCENTAGE")
+    void newMinIsGreaterThanMax() {
+        final var newMin = 100;
+
+        generator.minSize(newMin);
+
+        assertThat(generator.getMaxSize())
+                .isEqualTo(calculatePercentage(newMin, PERCENTAGE));
+    }
+
+    @Test
+    @DisplayName("newMin == max: new max should be set to greater than newMin by PERCENTAGE")
+    void newMinIsEqualToMax() {
+        final var newMin = 100;
+
+        generator.maxSize(0).minSize(newMin);
+
+        assertThat(generator.getMaxSize())
+                .isEqualTo(calculatePercentage(newMin, PERCENTAGE));
+    }
+
+    @Test
+    void size() {
+        final var size = 2;
+
+        generator.size(size);
+
+        assertThat(generator.getMinSize()).isEqualTo(size);
+        assertThat(generator.getMaxSize()).isEqualTo(size);
+    }
+
+    @Test
+    void minValidation() {
+        assertThatThrownBy(() -> generator.minSize(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContaining("size must not be negative: -1");
+    }
+
+    @Test
+    void maxValidation() {
+        assertThatThrownBy(() -> generator.maxSize(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContaining("size must not be negative: -1");
+    }
+
+    private int calculatePercentage(final int initial, final int percentage) {
+        return initial + initial * percentage / 100;
+    }
+
+    /**
+     * Subclass to expose getters.
+     */
+    private static class SeqGeneratorExt<T> extends SeqGenerator<T> {
+
+        public SeqGeneratorExt(final GeneratorContext context) {
+            super(context);
+        }
+
+        @Override
+        protected SeqBuilder<T> tryGenerateNonNull(final Random random) {
+            throw new InstancioException(getClass() + " should delegate to another generator");
+        }
+
+        int getMinSize() {
+            return minSize;
+        }
+
+        int getMaxSize() {
+            return maxSize;
+        }
+    }
+
+}

--- a/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/SeqSpecsTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/generator/specs/SeqSpecsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright (c) 2023 MovementSciences AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package ch.movementsciences.instancio.vavr.generator.specs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
 import ch.movementsciences.instancio.vavr.internal.generator.SeqGenerator;
@@ -27,9 +31,6 @@ import org.instancio.support.DefaultRandom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SeqSpecsTest {
 

--- a/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/CharSeqGeneratorTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/CharSeqGeneratorTest.java
@@ -1,4 +1,26 @@
+/*
+ * Copyright (c) 2023 MovementSciences AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ch.movementsciences.instancio.vavr.internal.generator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import io.vavr.collection.CharSeq;
 import org.instancio.Random;
@@ -9,12 +31,6 @@ import org.instancio.settings.Settings;
 import org.instancio.support.DefaultRandom;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
 
 class CharSeqGeneratorTest {
     private static final int MIN_SIZE = 101;

--- a/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/CharSeqGeneratorTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/CharSeqGeneratorTest.java
@@ -1,0 +1,61 @@
+package ch.movementsciences.instancio.vavr.internal.generator;
+
+import io.vavr.collection.CharSeq;
+import org.instancio.Random;
+import org.instancio.generator.AfterGenerate;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.support.DefaultRandom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+class CharSeqGeneratorTest {
+    private static final int MIN_SIZE = 101;
+    private static final int MAX_SIZE = 102;
+    private static final int SAMPLE_SIZE = 10_000;
+    private static final int PERCENTAGE_THRESHOLD = 10;
+    private static final Settings settings = Settings.defaults()
+            .set(Keys.COLLECTION_MIN_SIZE, MIN_SIZE)
+            .set(Keys.COLLECTION_MAX_SIZE, MAX_SIZE)
+            .set(Keys.COLLECTION_NULLABLE, true);
+    private static final Random random = new DefaultRandom();
+    private static final GeneratorContext context = new GeneratorContext(settings, random);
+    private final CharSeqGenerator generator = new CharSeqGenerator(context);
+
+    @Test
+    void apiMethod() {
+        assertThat(generator.apiMethod()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should generate either an empty charSeq or null")
+    void generateNullableSeq() {
+        final Set<Object> results = new HashSet<>();
+        final int[] counts = new int[2];
+
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            final var result = generator.generate(random);
+            results.add(result);
+            counts[result == null ? 0 : 1]++;
+        }
+
+        assertThat(results)
+                .containsNull()
+                .hasAtLeastOneElementOfType(CharSeq.class);
+
+        assertThat(counts[1])
+                .as("Expecting 5/6 of results to be non-null")
+                .isCloseTo((5 * SAMPLE_SIZE) / 6, withPercentage(PERCENTAGE_THRESHOLD));
+
+        HintsAssert.assertHints(generator.hints())
+                .isEmpty()
+                .afterGenerate(AfterGenerate.DO_NOT_MODIFY);
+    }
+}

--- a/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/HintsAssert.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/HintsAssert.java
@@ -21,6 +21,8 @@ import org.instancio.generator.Hints;
 import org.instancio.internal.generator.InternalContainerHint;
 import org.instancio.internal.generator.InternalGeneratorHint;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("UnusedReturnValue")
@@ -46,6 +48,15 @@ public class HintsAssert extends AbstractAssert<HintsAssert, Hints> {
 
     public HintsAssert nullableResult(boolean expected) {
         assertThat(actual.get(InternalGeneratorHint.class).nullableResult()).isEqualTo(expected);
+        return this;
+    }
+
+    public HintsAssert isEmpty() {
+        assertThat(actual)
+                .extracting("hintMap")
+                .isInstanceOfSatisfying(Map.class, map ->
+                        assertThat(map).isEmpty()
+                );
         return this;
     }
 }

--- a/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/HintsAssert.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/HintsAssert.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright (c) 2023 MovementSciences AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package ch.movementsciences.instancio.vavr.internal.generator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
 
 import org.assertj.core.api.AbstractAssert;
 import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Hints;
 import org.instancio.internal.generator.InternalContainerHint;
 import org.instancio.internal.generator.InternalGeneratorHint;
-
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("UnusedReturnValue")
 public class HintsAssert extends AbstractAssert<HintsAssert, Hints> {

--- a/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/HintsAssert.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/HintsAssert.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.movementsciences.instancio.vavr.internal.generator;
+
+import org.assertj.core.api.AbstractAssert;
+import org.instancio.generator.AfterGenerate;
+import org.instancio.generator.Hints;
+import org.instancio.internal.generator.InternalContainerHint;
+import org.instancio.internal.generator.InternalGeneratorHint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("UnusedReturnValue")
+public class HintsAssert extends AbstractAssert<HintsAssert, Hints> {
+
+    private HintsAssert(Hints actual) {
+        super(actual, HintsAssert.class);
+    }
+
+    public static HintsAssert assertHints(Hints actual) {
+        return new HintsAssert(actual);
+    }
+
+    public HintsAssert afterGenerate(AfterGenerate expected) {
+        assertThat(actual.afterGenerate()).isEqualTo(expected);
+        return this;
+    }
+
+    public HintsAssert containerHintGenerateEntriesIsBetween(int min, int max) {
+        assertThat(actual.get(InternalContainerHint.class).generateEntries()).isBetween(min, max);
+        return this;
+    }
+
+    public HintsAssert nullableResult(boolean expected) {
+        assertThat(actual.get(InternalGeneratorHint.class).nullableResult()).isEqualTo(expected);
+        return this;
+    }
+}

--- a/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGeneratorTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGeneratorTest.java
@@ -1,0 +1,62 @@
+package ch.movementsciences.instancio.vavr.internal.generator;
+
+import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
+import org.instancio.Random;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.support.DefaultRandom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+class SeqGeneratorTest {
+    private static final int MIN_SIZE = 101;
+    private static final int MAX_SIZE = 102;
+    private static final int SAMPLE_SIZE = 10_000;
+    private static final int PERCENTAGE_THRESHOLD = 10;
+    private static final Settings settings = Settings.defaults()
+            .set(Keys.COLLECTION_MIN_SIZE, MIN_SIZE)
+            .set(Keys.COLLECTION_MAX_SIZE, MAX_SIZE)
+            .set(Keys.COLLECTION_NULLABLE, true);
+    private static final Random random = new DefaultRandom();
+    private static final GeneratorContext context = new GeneratorContext(settings, random);
+    private final SeqGenerator<?> generator = new SeqGenerator<>(context);
+
+    @Test
+    void apiMethod() {
+        assertThat(generator.apiMethod()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should generate either an empty seq or null")
+    void generateNullableSeq() {
+        final Set<Object> results = new HashSet<>();
+        final int[] counts = new int[2];
+
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            final var result = generator.generate(random);
+            results.add(result);
+            counts[result == null ? 0 : 1]++;
+        }
+
+        assertThat(results)
+                .containsNull()
+                .hasAtLeastOneElementOfType(SeqBuilder.class)
+                .hasSize(2); // null and empty list
+
+        assertThat(counts[1])
+                .as("Expecting 5/6 of results to be non-null")
+                .isCloseTo((5 * SAMPLE_SIZE) / 6, withPercentage(PERCENTAGE_THRESHOLD));
+
+        HintsAssert.assertHints(generator.hints())
+                .containerHintGenerateEntriesIsBetween(MIN_SIZE, MAX_SIZE)
+                .nullableResult(true)
+                .afterGenerate(null);
+    }
+}

--- a/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGeneratorTest.java
+++ b/src/test/java/ch/movementsciences/instancio/vavr/internal/generator/SeqGeneratorTest.java
@@ -1,4 +1,26 @@
+/*
+ * Copyright (c) 2023 MovementSciences AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ch.movementsciences.instancio.vavr.internal.generator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import ch.movementsciences.instancio.vavr.internal.builder.SeqBuilder;
 import org.instancio.Random;
@@ -8,12 +30,6 @@ import org.instancio.settings.Settings;
 import org.instancio.support.DefaultRandom;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
 
 class SeqGeneratorTest {
     private static final int MIN_SIZE = 101;


### PR DESCRIPTION
- Extended `SeqGenerator` and `CharSeqGenerator` from `AbstractGenerator`. This allows to support the generation of null objects by default.
- Introduced the handling of a new case for the `IndexedSeq` class In `SeqBuilder`.
- Introduced a generatorContext in `VavrProvider` to make generation classes reproducibles, adding an init method where it's set up.
- Fixed `VavrContainerFactory` to support mapping functions of `CharSeq` type.
- Implemented several enhancements and additional tests cases in `CharSeqTest` and `SeqTest` to increase the coverage and correctness of tests, including the introduction of generatorSettingsSize().
- Added new tests to test `SeqSpec` and `CharSeqSpecs`, as well as to test that null objects are generated.